### PR TITLE
Modify Title of PEP 458

### DIFF
--- a/pep-0458-tuf-online-keys.rst
+++ b/pep-0458-tuf-online-keys.rst
@@ -1,5 +1,5 @@
 PEP: 458
-Title: Surviving a Compromise of PyPI
+Title: Securing the Link from PyPI to the End User
 Version: $Revision$
 Last-Modified: $Date$
 Author: Trishank Karthik Kuppusamy <trishank@nyu.edu>,


### PR DESCRIPTION
Protecting against a compromise of PyPI itself is the scope that was moved to PEP 480.