### PR TITLE
PEP 458: Add Paragraph to the 'In the Event of a Key Compromise' Subsection.  Addresses Issue #22.

### DIFF
--- a/pep-0458-tuf-online-keys.rst
+++ b/pep-0458-tuf-online-keys.rst
@@ -438,7 +438,7 @@ How to Establish Initial Trust in the PyPI Root Keys
 ----------------------------------------------------
 
 Package managers like pip need to ship a file named "root.json" with the
-installation files that users initially download. This includes information
+installation files that users initially download. This file includes information
 about the keys trusted for certain roles, as well as the root keys themselves.
 Any new version of "root.json" that clients may download are verified against
 the root keys that client's initially trust. If a root key is compromised, but
@@ -884,10 +884,10 @@ both the new and old root keys until all clients are known to have obtained the
 new *root.json* file (a safe assumption is that this will be a very long time
 or never).  Since *root.json* is only updated by clients that already trust a
 threshold number of the keys included in the new *root.json*, setting aside
-reserved off-pypi keys to sign *root.json* specifically for outdated clients is
+reserved off-pypi keys to sign *root.json* specifically for outdated clients is an
 option.  There is no risk posed by continuing to sign the *root.json* file with
-revoked keys as once clients have updated they no longer trust the revoked key.
-This is only to ensure outdated clients remain able to update. 
+revoked keys because once clients have updated they no longer trust the revoked key.
+This is only to ensure that outdated clients remain able to update. 
 
 It is also RECOMMENDED that PyPI sufficiently document compromises with
 security bulletins.  These security bulletins will be most informative when

--- a/pep-0458-tuf-online-keys.rst
+++ b/pep-0458-tuf-online-keys.rst
@@ -437,7 +437,7 @@ __ https://github.com/theupdateframework/tuf/tree/develop/tuf#delegations
 How to Establish Initial Trust in the PyPI Root Keys
 ----------------------------------------------------
 
-Package managers like pip need to ship a file called "root.json" with the
+Package managers like pip need to ship a file named "root.json" with the
 installation files that users initially download. This includes information
 about the keys trusted for certain roles, as well as the root keys themselves.
 Any new version of "root.json" that clients may download are verified against
@@ -876,6 +876,18 @@ only one of them may have been compromised.
 If a threshold number of *root* keys have been compromised, then PyPI MUST take
 the steps taken when the *targets* role has been compromised.  All of the
 *root* keys must also be replaced.
+
+To replace a compromised *root* key or any other top-level role key, the *root*
+role signs a new *root.json* file that lists the updated trusted keys for the
+role. When replacing *root* keys, PyPI will sign the new *root.json* file with
+both the new and old root keys until all clients are known to have obtained the
+new *root.json* file (a safe assumption is that this will be a very long time
+or never).  Since *root.json* is only updated by clients that already trust a
+threshold number of the keys included in the new *root.json*, setting aside
+reserved off-pypi keys to sign *root.json* specifically for outdated clients is
+option.  There is no risk posed by continuing to sign the *root.json* file with
+revoked keys as once clients have updated they no longer trust the revoked key.
+This is only to ensure outdated clients remain able to update. 
 
 It is also RECOMMENDED that PyPI sufficiently document compromises with
 security bulletins.  These security bulletins will be most informative when

--- a/pep-0458-tuf-online-keys.rst
+++ b/pep-0458-tuf-online-keys.rst
@@ -877,7 +877,7 @@ If a threshold number of *root* keys have been compromised, then PyPI MUST take
 the steps taken when the *targets* role has been compromised.  All of the
 *root* keys must also be replaced.
 
-To replace a compromised *root* key or any other top-level role key, the *root*
+In order to replace a compromised *root* key or any other top-level role key, the *root*
 role signs a new *root.json* file that lists the updated trusted keys for the
 role. When replacing *root* keys, PyPI will sign the new *root.json* file with
 both the new and old root keys until all clients are known to have obtained the


### PR DESCRIPTION
* Add paragraph to discuss how new `root.json` metadata should be signed by PyPI administrators following revocation or replacement of top-level role keys.