### PR TITLE
PEP 440: Remove PEP 426 references

### DIFF
--- a/pep-0440-versioning.rst
+++ b/pep-0440-versioning.rst
@@ -34,17 +34,36 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in RFC 2119.
 
-The following terms are to be interpreted as described in PEP 426:
+"Projects" are software components that are made available for integration.
+Projects include Python libraries, frameworks, scripts, plugins,
+applications, collections of data or other resources, and various
+combinations thereof. Public Python projects are typically registered on
+the `Python Package Index`_.
 
-* "Distributions"
-* "Releases"
-* "Build tools"
-* "Index servers"
-* "Publication tools"
-* "Installation tools"
-* "Automated tools"
-* "Projects"
+"Releases" are uniquely identified snapshots of a project.
 
+"Distributions" are the packaged files which are used to publish
+and distribute a release.
+
+"Build tools" are automated tools intended to run on development systems,
+producing source and binary distribution archives. Build tools may also be
+invoked by integration tools in order to build software distributed as
+sdists rather than prebuilt binary archives.
+
+"Index servers" are active distribution registries which publish version and
+dependency metadata and place constraints on the permitted metadata.
+
+"Publication tools" are automated tools intended to run on development
+systems and upload source and binary distribution archives to index servers.
+
+"Installation tools" are integration tools specifically intended to run on
+deployment targets, consuming source and binary distribution archives from
+an index server or other designated location and deploying them to the target
+system.
+
+"Automated tools" is a collective term covering build tools, index servers,
+publication tools, integration tools and any other software that produces
+or consumes distribution version and dependency metadata.
 
 Version scheme
 ==============
@@ -1084,9 +1103,8 @@ uploaded distributions. Direct references are intended as a tool for
 software integrators rather than publishers.
 
 Depending on the use case, some appropriate targets for a direct URL
-reference may be a valid ``source_url`` entry (see PEP 426), an sdist, or
-a wheel binary archive. The exact URLs and targets supported will be tool
-dependent.
+reference may be an sdist or a wheel binary archive. The exact URLs and
+targets supported will be tool dependent.
 
 For example, a local source archive may be referenced directly::
 


### PR DESCRIPTION
PEP 426 is in Draft status, and will not be accepted. PEP 508 is Accepted, and is the way forward, so replace references of 426 with 508 inside PEP 440.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/interoperability-peps/60)
<!-- Reviewable:end -->
