### PR TITLE
Fix identifier grammar.

### DIFF
--- a/pep-0508-dependency-specifiers.rst
+++ b/pep-0508-dependency-specifiers.rst
@@ -124,9 +124,8 @@ environments::
 Optional components of a distribution may be specified using the extras
 field::
 
-    identifier    = letterOrDigit (
-                    letterOrDigit |
-                    (( letterOrDigit | '-' | '_' | '.')* letterOrDigit ) )*
+    identifer_end = letterOrDigit | (('-' | '_' | '.' )* letterOrDigit)
+    identifier    = letterOrDigit identifier_end*
     name          = identifier
     extras_list   = identifier (wsp* ',' wsp* identifier)*
     extras        = '[' wsp* extras_list? wsp* ']'
@@ -388,9 +387,8 @@ The complete parsley grammar::
                       | marker_and:m -> m
     marker        = marker_or
     quoted_marker = ';' wsp* marker
-    identifier    = <letterOrDigit (
-                    letterOrDigit |
-                    (( letterOrDigit | '-' | '_' | '.')* letterOrDigit ) )*>
+    identifer_end = letterOrDigit | (('-' | '_' | '.' )* letterOrDigit)
+    identifier    = < letterOrDigit identifier_end* >
     name          = identifier
     extras_list   = identifier:i (wsp* ',' wsp* identifier)*:ids -> [i] + ids
     extras        = '[' wsp* extras_list?:e wsp* ']' -> e
@@ -475,6 +473,7 @@ A test program - if the grammar is in a string ``grammar``::
         """
     tests = [
         "A",
+        "A.B-C_D",
         "aa",
         "name",
         "name>=3",


### PR DESCRIPTION
We had a bug :/. The grammar is sane for humans but not PEG engines.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/interoperability-peps/61)
<!-- Reviewable:end -->
